### PR TITLE
Fixed shared genome proportions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ g1-b1-i1 g3-b1-i1     2           2                 0.2369          0.1163      
  * `shared_ancestors` is the most likeliest number of shared ancestors, if it is 0, then one relative is a direct descendant of the other, 
  if 1 then they probably have one common ancestor, i.e. half siblings, if 2 then they have common mother and father, for example.  
  * `final_degree` is simply `king_degree` for close relatives up to 3rd degree and `ersa_degree` for distant relatives.
- * `total_seg_len` is the total length of all IBD segments, for the first 3 degrees it is calculated using KING IBD data, 
+ * `total_seg_len` is the total length of all IBD1 segments, for the first 3 degrees it is calculated using KING IBD data, 
    for the 4th+ degrees it is calculated using IBID or Germline IBD data.
  * `seg_count` is the total number of all IBD segments found by KING for the first 3 degrees and found by IBIS\Germline for the 4th+ degrees.
 

--- a/rules/relatives_ibis.smk
+++ b/rules/relatives_ibis.smk
@@ -64,7 +64,7 @@ rule ersa:
         
         FILES="{input.ibd}"
         TEMPFILE=ersa/temp_relatives.tsv
-
+        rm $TEMPFILE
         for input_file in $FILES; do
             ersa --avuncular-adj -ci --alpha {params.alpha} --dmax 14 -t $ERSA_T -l $ERSA_L -th $ERSA_TH $input_file -o $TEMPFILE  |& tee {log}
             cat $TEMPFILE >> {output}

--- a/rules/relatives_ibis.smk
+++ b/rules/relatives_ibis.smk
@@ -64,10 +64,18 @@ rule ersa:
         
         FILES="{input.ibd}"
         TEMPFILE=ersa/temp_relatives.tsv
-        rm $TEMPFILE
+        rm -f $TEMPFILE
+        rm -f {output}
+        
         for input_file in $FILES; do
+
             ersa --avuncular-adj -ci --alpha {params.alpha} --dmax 14 -t $ERSA_T -l $ERSA_L -th $ERSA_TH $input_file -o $TEMPFILE  |& tee {log}
-            cat $TEMPFILE >> {output}
+
+            if [[ "$input_file" == "${{FILES[0]}}" ]]; then
+                cat $TEMPFILE >> {output}
+            else
+                sed 1d $TEMPFILE >> {output}
+            fi
         done
         """
 

--- a/rules/relatives_ibis_king.smk
+++ b/rules/relatives_ibis_king.smk
@@ -126,7 +126,6 @@ rule merge_king_ersa:
     input:
         king=rules.run_king.output['king'],
         king_segments=rules.run_king.output['segments'],
-        bucket_dir=directory('ibd'),
         ersa=rules.ersa.output[0],
         kinship=rules.run_king.output['kinship'],
         kinship0=rules.run_king.output['kinship0'],

--- a/rules/relatives_ibis_king.smk
+++ b/rules/relatives_ibis_king.smk
@@ -104,10 +104,18 @@ rule ersa:
         
         FILES="{input.ibd}"
         TEMPFILE=ersa/temp_relatives.tsv
-
+        rm -f $TEMPFILE
+        rm -f {output}
+        
         for input_file in $FILES; do
+
             ersa --avuncular-adj -ci --alpha {params.alpha} --dmax 14 -t $ERSA_T -l $ERSA_L -th $ERSA_TH $input_file -o $TEMPFILE  |& tee {log}
-            cat $TEMPFILE >> {output}
+
+            if [[ "$input_file" == "${{FILES[0]}}" ]]; then
+                cat $TEMPFILE >> {output}
+            else
+                sed 1d $TEMPFILE >> {output}
+            fi
         done
         """
 

--- a/scripts/postprocess_ersa.py
+++ b/scripts/postprocess_ersa.py
@@ -95,27 +95,38 @@ if __name__ == '__main__':
     relatives = ibd.merge(ersa, how='outer', left_index=True, right_index=True)
 
     # It is impossible to have more than 50% of ibd2 segments unless you are monozygotic twins or duplicates.
-    dup_mask = relatives.total_seg_len_ibd2 > 1800
-    fs_mask = (relatives.total_seg_len > 2100) & (relatives.total_seg_len_ibd2 > 450) & (~dup_mask)
-    po_mask = (relatives.total_seg_len / 3540 > 0.8) & (~fs_mask) & (~dup_mask)
+    GENOME_CM_LEN = 3440
+    DUPLICATES_THRESHOLD = 1750
+    FS_TOTAL_THRESHOLD = 2100
+    FS_IBD2_THRESHOLD = 450
+    dup_mask = relatives.total_seg_len_ibd2 > DUPLICATES_THRESHOLD
+    fs_mask = (relatives.total_seg_len > FS_TOTAL_THRESHOLD) & (relatives.total_seg_len_ibd2 > FS_IBD2_THRESHOLD) & (~dup_mask)
+    po_mask = (relatives.total_seg_len / GENOME_CM_LEN > 0.8) & (~fs_mask) & (~dup_mask)
     print(f'We have {sum(dup_mask)} duplicates, {sum(fs_mask)} full siblings and {sum(po_mask)} parent-offspring relationships')
 
     relatives.loc[:, 'final_degree'] = relatives.ersa_degree
     relatives.loc[dup_mask, 'final_degree'] = 0
     relatives.loc[po_mask, 'final_degree'] = 1
 
-    relatives.loc[(~po_mask) & (relatives.final_degree == 1)] = 2  # to eliminate some ersa false positives
+    relatives.loc[(~po_mask) & (relatives.final_degree == 1), 'final_degree'] = 2  # to eliminate some ersa false positives
     relatives.loc[fs_mask, 'final_degree'] = 2
     relatives.loc[:, 'relation'] = relatives.ersa_degree.astype(str)
     relatives.loc[po_mask, 'relation'] = 'PO'
     relatives.loc[fs_mask, 'relation'] = 'FS'
     relatives.loc[dup_mask, 'relation'] = 'MZ/Dup'
-    # if king is unsure or king degree > 3 then we use ersa distant relatives estimation
 
     # approximate calculations, IBD share is really small in this case
     relatives.loc[pandas.isna(relatives.total_seg_len_ibd2), 'total_seg_len_ibd2'] = 0
     relatives.loc[pandas.isna(relatives.seg_count_ibd2), 'seg_count_ibd2'] = 0
-    relatives.loc[:, 'shared_genome_proportion'] = 0.5*relatives.total_seg_len / 3540 + relatives.total_seg_len_ibd2 / 3540
+    '''
+        IBIS and ERSA do not distinguish IBD1 and IBD2 segments
+        shared_genome_proportion is a proportion of identical alleles
+        i.e. shared_genome_proportion of [(0/0), (0/1)] and [(0/0), (1/1)] should be 3/4
+        GENOME_SEG_LEN is length of centimorgans of the haplotype
+        ibd2 segments span two haplotypes, therefore their length should be doubled
+        total_seg_len includes both ibd1 and ibd2 segments length
+    '''
+    relatives.loc[:, 'shared_genome_proportion'] = (relatives.total_seg_len - relatives.total_seg_len_ibd2) / (2*GENOME_CM_LEN) + relatives.total_seg_len_ibd2*2 / (2*GENOME_CM_LEN)
     relatives.loc[relatives.shared_genome_proportion > 1.0, 'shared_genome_proportion'] = 1.0
     logging.info(f'final degree not null: {pandas.notna(relatives.final_degree).sum()}')
     relatives.loc[pandas.notna(relatives.final_degree), :].to_csv(output_path, sep='\t')

--- a/workflows/bundle/Snakefile
+++ b/workflows/bundle/Snakefile
@@ -24,31 +24,59 @@ BUNDLE_md5         = config["reference"]["bundle" if full else "bundle_min"]["md
 
 CHROMOSOMES = [str(i) for i in range(1, 23)]
 
-rule all:
-    output:
-        GRCh37_fasta = GRCH37_FASTA,
-        GRCh37_fasta_dict = expand("{ref}.dict",ref=GRCH37_FASTA),
-        GENETIC_MAP = GENETIC_MAP,
-        genetic_map_GRCh37 = expand(GENETIC_MAP_GRCH37, chrom=CHROMOSOMES),
-        cmmap = expand(CMMAP, chrom=CHROMOSOMES),
-        lift_chain = LIFT_CHAIN,
-        SITE_1000GENOME = SITE_1000GENOME,
-        pedsim_map = PEDSIM_MAP,
-        affymetrix_chip = AFFYMETRIX_CHIP,
-        vcfRef = expand(REF_VCF, chrom=CHROMOSOMES if full else []),
-        refHaps = expand(REF_HAPS, chrom=CHROMOSOMES if full else [])
-    conda:
-        "../../envs/download.yaml"
-    log:
-        "logs/ref/download_bundle.log"
-    shell:
-        """
-            wget "{BUNDLE_url}{AZURE_KEY}" -O {REF_DIR}/{BUNDLE_basename} --tries 50 |& tee -a {log}
-            sum=$(md5sum {REF_DIR}/{BUNDLE_basename} | cut -d " " -f1)
-            if [ $sum != {BUNDLE_md5} ]; then
-                echo "md5 sum of BUDNLE is invalid" |& tee -a {log}
-                exit 1
-            fi  
-            tar -xzvf {REF_DIR}/{BUNDLE_basename} -C {REF_DIR} |& tee -a {log}
-            rm -f {REF_DIR}/{BUNDLE_basename} |& tee -a {log}
-        """
+if full:
+    rule all:
+        output:
+            GRCh37_fasta = GRCH37_FASTA,
+            GRCh37_fasta_dict = expand("{ref}.dict",ref=GRCH37_FASTA),
+            GENETIC_MAP = GENETIC_MAP,
+            genetic_map_GRCh37 = expand(GENETIC_MAP_GRCH37, chrom=CHROMOSOMES),
+            cmmap = expand(CMMAP, chrom=CHROMOSOMES),
+            lift_chain = LIFT_CHAIN,
+            SITE_1000GENOME = SITE_1000GENOME,
+            pedsim_map = PEDSIM_MAP,
+            affymetrix_chip = AFFYMETRIX_CHIP,
+            vcfRef = expand(REF_VCF, chrom=CHROMOSOMES),
+            refHaps = expand(REF_HAPS, chrom=CHROMOSOMES)
+        conda:
+            "../../envs/download.yaml"
+        log:
+            "logs/ref/download_bundle.log"
+        shell:
+            """
+                wget "{BUNDLE_url}{AZURE_KEY}" -O {REF_DIR}/{BUNDLE_basename} --tries 50 |& tee -a {log}
+                sum=$(md5sum {REF_DIR}/{BUNDLE_basename} | cut -d " " -f1)
+                if [ $sum != {BUNDLE_md5} ]; then
+                    echo "md5 sum of BUDNLE is invalid" |& tee -a {log}
+                    exit 1
+                fi  
+                tar -xzvf {REF_DIR}/{BUNDLE_basename} -C {REF_DIR} |& tee -a {log}
+                rm -f {REF_DIR}/{BUNDLE_basename} |& tee -a {log}
+            """
+else:
+    rule all:
+        output:
+            GRCh37_fasta = GRCH37_FASTA,
+            GRCh37_fasta_dict = expand("{ref}.dict",ref=GRCH37_FASTA),
+            GENETIC_MAP = GENETIC_MAP,
+            genetic_map_GRCh37 = expand(GENETIC_MAP_GRCH37, chrom=CHROMOSOMES),
+            cmmap = expand(CMMAP, chrom=CHROMOSOMES),
+            lift_chain = LIFT_CHAIN,
+            SITE_1000GENOME = SITE_1000GENOME,
+            pedsim_map = PEDSIM_MAP,
+            affymetrix_chip = AFFYMETRIX_CHIP
+        conda:
+            "../../envs/download.yaml"
+        log:
+            "logs/ref/download_bundle.log"
+        shell:
+            """
+                wget "{BUNDLE_url}{AZURE_KEY}" -O {REF_DIR}/{BUNDLE_basename} --tries 50 |& tee -a {log}
+                sum=$(md5sum {REF_DIR}/{BUNDLE_basename} | cut -d " " -f1)
+                if [ $sum != {BUNDLE_md5} ]; then
+                    echo "md5 sum of BUDNLE is invalid" |& tee -a {log}
+                    exit 1
+                fi  
+                tar -xzvf {REF_DIR}/{BUNDLE_basename} -C {REF_DIR} |& tee -a {log}
+                rm -f {REF_DIR}/{BUNDLE_basename} |& tee -a {log}
+            """


### PR DESCRIPTION
1. With --flow ibis_king grape now calculates IBD1 and IBD2 shares from KING data for the 0-3 degrees.
2. Fixed a bug with parsing ersa output for large datasets.
3. Fixed a bug with setting every values for some rows in relatives.tsv to 2.
4. Fixed total_seg_len and total_seg_len_ibd2 calculation. Now total_seg_len corresponds to only ibd1 segments.