### PR TITLE
Fix Dropbox filesize checking

### DIFF
--- a/validate_files.py
+++ b/validate_files.py
@@ -47,7 +47,7 @@ def get_dropbox_filesize(url_parsed: ParseResult) -> int:
     url_parsed = url_parsed._replace(query=query)
     url = urlunparse(url_parsed)
     file = urlopen(Request(url, method='HEAD'))
-    return int(file.headers.get('X-Dropbox-Content-Length'))
+    return int(file.headers.get('X-Dropbox-Content-Length') or file.headers.get('Content-Length'))
 
 
 def get_url(url, access_keys):


### PR DESCRIPTION
In some cases Dropbox sends filesize in `X-Dropbox-Content-Length` header but sometimes in `Content-Length`.
This fix just checks for both cases.