### PR TITLE
Fix simbig workflow

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -421,7 +421,9 @@ if __name__ == '__main__':
         )
 
     if args.command == 'preprocess':
-        shutil.copy(args.vcf_file, os.path.join(args.directory, 'input.vcf.gz'))
+        # shutil.copy(args.vcf_file, os.path.join(args.directory, 'input.vcf.gz'))
+        if not os.path.exists(os.path.join(args.directory, 'input.vcf.gz')):
+            os.symlink(args.vcf_file, os.path.join(args.directory, 'input.vcf.gz'))
 
     if args.command in ['preprocess', 'find', 'reference', 'bundle', 'remove_relatives', 'compute-weight-mask']:
         if args.directory != '.':

--- a/launcher.py
+++ b/launcher.py
@@ -420,7 +420,7 @@ if __name__ == '__main__':
             os.path.join(args.directory, 'config.yaml')
         )
 
-    if args.command == 'preprocess':
+    if args.command == 'preprocess' or args.command == 'remove_relatives':
         # shutil.copy(args.vcf_file, os.path.join(args.directory, 'input.vcf.gz'))
         if not os.path.exists(os.path.join(args.directory, 'input.vcf.gz')):
             os.symlink(args.vcf_file, os.path.join(args.directory, 'input.vcf.gz'))

--- a/remove_relatives
+++ b/remove_relatives
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -it -v `pwd`/workdir:/media -v /etc/localtime:/etc/localtime:ro genx_relatives:latest launcher.py remove_relatives "$@"

--- a/rules/filter.smk
+++ b/rules/filter.smk
@@ -1,6 +1,6 @@
 rule select_bad_samples:
     input:
-        vcf='vcf/{batch}.vcf.gz'
+        vcf='vcf/{batch}_merged_lifted.vcf.gz'
     output:
         bad_samples='vcf/{batch}_lifted_vcf.badsamples',
         report='results/{batch}_bad_samples_report.tsv',
@@ -25,7 +25,7 @@ rule select_bad_samples:
 
 rule plink_filter:
     input:
-        vcf='vcf/{batch}_merged_lifted_id.vcf.gz',
+        vcf='vcf/{batch}_merged_lifted.vcf.gz',
         bad_samples=rules.select_bad_samples.output.bad_samples
     output:
         bed = temp('plink/{batch}_merged_filter.bed'),
@@ -107,7 +107,7 @@ rule prepare_vcf:
         bim='plink/{batch}_merged_mapped.bim',
         fam='plink/{batch}_merged_mapped.fam'
     output:
-        vcf='vcf/{batch}_merged_mapped_sorted.vcf.gz',
+        bcf='vcf/{batch}_merged_mapped_sorted.bcf.gz',
         temp_vcf=temp('vcf/{batch}_merged_mapped_regions.vcf.gz'),
         temp_vcf_csi=temp('vcf/{batch}_merged_mapped_regions.vcf.gz.csi'),
         bed=temp('plink/{batch}_merged_mapped_alleled.bed'),
@@ -131,7 +131,7 @@ rule prepare_vcf:
         bcftools sort -T vcf/temp_{wildcards.batch} vcf/{wildcards.batch}_merged_mapped_clean.vcf.gz -O z -o {output.temp_vcf} |& tee -a {log.vcf}
         bcftools index -f {output.temp_vcf} |& tee -a {log.vcf}
         # need to check output for the potential issues
-        bcftools view {output.temp_vcf} --regions 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 -O z -o {output.vcf}
-        bcftools norm --check-ref e -f {GRCH37_FASTA} vcf/{wildcards.batch}_merged_mapped_sorted.vcf.gz -O u -o /dev/null |& tee -a {log.vcf}
-        bcftools index -f {output.vcf} | tee -a {log.vcf}
+        bcftools view {output.temp_vcf} --regions 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22 -O b -o {output.bcf}
+        bcftools norm --check-ref e -f {GRCH37_FASTA} vcf/{wildcards.batch}_merged_mapped_sorted.bcf.gz -O u -o /dev/null |& tee -a {log.vcf}
+        bcftools index -f {output.bcf} | tee -a {log.vcf}
         """

--- a/rules/filter.smk
+++ b/rules/filter.smk
@@ -107,7 +107,7 @@ rule prepare_vcf:
         bim='plink/{batch}_merged_mapped.bim',
         fam='plink/{batch}_merged_mapped.fam'
     output:
-        vcf=temp('vcf/{batch}_merged_mapped_sorted.vcf.gz'),
+        vcf='vcf/{batch}_merged_mapped_sorted.vcf.gz',
         temp_vcf=temp('vcf/{batch}_merged_mapped_regions.vcf.gz'),
         temp_vcf_csi=temp('vcf/{batch}_merged_mapped_regions.vcf.gz.csi'),
         bed=temp('plink/{batch}_merged_mapped_alleled.bed'),

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -125,12 +125,12 @@ if need_phase:
 else:
     rule copy_phase:
         input:
-            vcf='vcf/{batch}_merged_mapped_sorted.bcf.gz'
+            bcf='vcf/{batch}_merged_mapped_sorted.bcf.gz'
         output:
-            vcf='phase/{batch}_merged_phased.bcf.gz'
+            bcf='phase/{batch}_merged_phased.bcf.gz'
         shell:
             '''
-                ln -sr {input.vcf} {output.vcf}
+                ln -sr {input.bcf} {output.bcf}
             '''
 
 
@@ -148,13 +148,11 @@ else:
         input:
             bcf=bcf_input
         output:
-            vcf=vcf_output,
-            fam='preprocessed/data.fam'
+            vcf=vcf_output
         conda:
             'bcftools'
         shell:
             '''
-                bcftools query --list-samples {input.bcf} >> {output.fam}
                 bcftools view {input.bcf} -O z -o {output.vcf}
             '''
 
@@ -305,3 +303,16 @@ if not flow == 'rapid':
             '''
             (add-map-plink.pl -cm {input.bim} {params.genetic_map_GRCh37}> {output}) |& tee -a {log}
             '''
+else:
+    rule create_samples_list:
+        input:
+            bcf_input = 'phase/batch1_merged_phased.bcf.gz'
+        output:
+            fam='preprocessed/data.fam'
+        conda:
+            'bcftools'
+        shell:
+            '''
+                bcftools query --list-samples {input.bcf} >> {output.fam}
+            '''
+

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -104,31 +104,17 @@ else:
                 ln -sr {input.vcf} {output.vcf}
             '''
 
-
-rule recode_snp_ids:
-    input:
-        vcf='vcf/{batch}_merged_lifted.vcf.gz'
-    output:
-        bcf=temp('vcf/{batch}_merged_lifted_id.bcf.gz')
-    conda:
-        'bcftools'
-    shell:
-        '''
-            bcftools annotate --set-id "%CHROM:%POS:%REF:%FIRST_ALT" {input.vcf} -O b -o {output.bcf}
-        '''
-
-
 if flow == 'rapid' or flow == 'germline-king':
     rule phase_preserving_filter:
         input:
-            bcf = 'vcf/{batch}_merged_lifted_id.bcf.gz'
+            vcf = 'vcf/{batch}_imputation_removed.vcf.gz'
         output:
             bcf = 'vcf/{batch}_merged_mapped_sorted.bcf.gz'
         conda:
             'bcftools'
         shell:
             '''
-                bcftools view --min-af 0.05 {input.bcf} -O b -o {output.bcf}
+                bcftools annotate --set-id "%CHROM:%POS:%REF:%FIRST_ALT" {input.vcf} | bcftools view --min-af 0.05 -O b -o {output.bcf}
             '''
 else:
     include: '../rules/filter.smk'

--- a/rules/preprocessing.smk
+++ b/rules/preprocessing.smk
@@ -48,10 +48,10 @@ else:
         input:
             vcf = 'input.vcf.gz'
         output:
-            vcf=temp('vcf/batch1.vcf.gz')
+            vcf='vcf/batch1.vcf.gz'
         shell:
             '''
-            cp {input.vcf} vcf/batch1.vcf.gz
+                ln -sr {input.vcf} {output.vcf}
             '''
 
 
@@ -68,29 +68,11 @@ else:
         input:
             vcf='vcf/{batch}.vcf.gz'
         output:
-            vcf=temp('vcf/{batch}_imputation_removed.vcf.gz')
+            vcf='vcf/{batch}_imputation_removed.vcf.gz'
         shell:
             '''
-                cp {input.vcf} {output.vcf}
+                ln -sr {input.vcf} {output.vcf}
             '''
-
-
-rule recode_vcf:
-    input:
-        vcf='vcf/{batch}_imputation_removed.vcf.gz'
-    output:
-        vcf=temp('vcf/{batch}_merged_recoded.vcf.gz')
-    conda:
-        'bcftools'
-    shell:
-        '''
-        rm -f chr_name_conv.txt
-        for i in {{1..22}} X Y XY MT
-        do
-            echo "chr$i $i" >> chr_name_conv.txt
-        done
-        bcftools annotate --rename-chrs chr_name_conv.txt {input.vcf} | bcftools view -m2 -M2 -v snps -t "^X,Y,XY,MT" -O z -o {output.vcf}
-        '''
 
 
 if assembly == 'hg38':
@@ -116,10 +98,10 @@ else:
         input:
             vcf='vcf/{batch}_imputation_removed.vcf.gz'
         output:
-            vcf=temp('vcf/{batch}_merged_lifted.vcf.gz')
+            vcf='vcf/{batch}_merged_lifted.vcf.gz'
         shell:
             '''
-                cp {input.vcf} {output.vcf}
+                ln -sr {input.vcf} {output.vcf}
             '''
 
 
@@ -127,27 +109,26 @@ rule recode_snp_ids:
     input:
         vcf='vcf/{batch}_merged_lifted.vcf.gz'
     output:
-        vcf=temp('vcf/{batch}_merged_lifted_id.vcf.gz')
+        bcf=temp('vcf/{batch}_merged_lifted_id.bcf.gz')
     conda:
         'bcftools'
     shell:
         '''
-            bcftools annotate --set-id "%CHROM:%POS:%REF:%FIRST_ALT" {input.vcf} -O z -o {output.vcf}
+            bcftools annotate --set-id "%CHROM:%POS:%REF:%FIRST_ALT" {input.vcf} -O b -o {output.bcf}
         '''
-
 
 
 if flow == 'rapid' or flow == 'germline-king':
     rule phase_preserving_filter:
         input:
-            vcf = temp('vcf/{batch}_merged_lifted_id.vcf.gz')
+            bcf = 'vcf/{batch}_merged_lifted_id.bcf.gz'
         output:
-            vcf = temp('vcf/{batch}_merged_mapped_sorted.vcf.gz')
+            bcf = 'vcf/{batch}_merged_mapped_sorted.bcf.gz'
         conda:
             'bcftools'
         shell:
             '''
-                bcftools view --min-af 0.05 {input.vcf} -O z -o {output.vcf}
+                bcftools view --min-af 0.05 {input.bcf} -O b -o {output.bcf}
             '''
 else:
     include: '../rules/filter.smk'
@@ -158,12 +139,12 @@ if need_phase:
 else:
     rule copy_phase:
         input:
-            vcf='vcf/{batch}_merged_mapped_sorted.vcf.gz'
+            vcf='vcf/{batch}_merged_mapped_sorted.bcf.gz'
         output:
-            vcf=temp('phase/{batch}_merged_phased.vcf.gz')
+            vcf='phase/{batch}_merged_phased.bcf.gz'
         shell:
             '''
-                cp {input.vcf} {output.vcf}
+                ln -sr {input.vcf} {output.vcf}
             '''
 
 
@@ -172,164 +153,169 @@ if need_imputation:
 else:
     if NUM_BATCHES > 1:
         vcf_output = 'preprocessed/{batch}_data.vcf.gz'
-        vcf_input = 'phase/{batch}_merged_phased.vcf.gz'
+        bcf_input = 'phase/{batch}_merged_phased.bcf.gz'
     else:
         vcf_output = 'preprocessed/data.vcf.gz'
-        vcf_input = 'phase/batch1_merged_phased.vcf.gz'
+        bcf_input = 'phase/batch1_merged_phased.bcf.gz'
 
     checkpoint copy_imputation:
         input:
-            vcf=vcf_input
+            bcf=bcf_input
         output:
-            vcf=vcf_output
-        shell:
-            '''
-               cp {input.vcf} {output.vcf}
-            '''
-
-
-if NUM_BATCHES > 1:
-    checkpoint convert_mapped_to_plink:
-        input:
-            vcf='preprocessed/{batch}_data.vcf.gz'
-        output:
-            bed='preprocessed/{batch}_data.bed',
-            fam='preprocessed/{batch}_data.fam',
-            bim='preprocessed/{batch}_data.bim'
-        params:
-            out='preprocessed/{batch}_data'
-        conda:
-            'plink'
-        log:
-            'logs/plink/convert_mapped_to_plink{batch}.log'
-        benchmark:
-            'benchmarks/plink/convert_mapped_to_plink{batch}.txt'
-        shell:
-            '''
-            plink --vcf {input} --make-bed --out {params.out} |& tee {log}
-            '''
-
-
-    def get_merge_bed_input(wildcards):
-        with open('pass_batches.list','r') as list:
-            batches_left = []
-            for line in list:
-                batches_left.append(line.strip('\n'))
-            bim = ['preprocessed/{s}_data.bim'.format(s=batch) for batch in batches_left]
-            bed = ['preprocessed/{s}_data.bed'.format(s=batch) for batch in batches_left]
-            fam = ['preprocessed/{s}_data.fam'.format(s=batch) for batch in batches_left]
-        return bed + bim + fam
-
-    rule merge_bed:
-        input:
-            get_merge_bed_input
-        output:
-            bed='preprocessed/data.bed',
-            fam='preprocessed/data.fam',
-            bim='preprocessed/data.bim'
-        threads:
-            workflow.cores
-        conda:
-            'plink'
-        shell:
-            '''
-            rm files_list.txt || true
-            for file in {input}
-            do
-                if [[ $file == *.fam ]]
-                then
-                    echo ${{file%.*}} >> files_list.txt
-                fi
-            done
-
-            plink --merge-list files_list.txt --make-bed --out preprocessed/data
-            rm files_list.txt
-            '''
-
-
-    rule index_vcf:
-        input:
-            batches_vcf='preprocessed/{batch}_data.vcf.gz'
-        output:
-            batches_vcf_index=temp('preprocessed/{batch}_data.vcf.gz.csi')
+            vcf=vcf_output,
+            fam='preprocessed/data.fam'
         conda:
             'bcftools'
         shell:
             '''
-            bcftools index -f {input.batches_vcf}
+                bcftools query --list-samples {input.bcf} >> {output.fam}
+                bcftools view {input.bcf} -O z -o {output.vcf}
             '''
 
-    def get_merge_vcf_input(wildcards):
-        with open('pass_batches.list', 'r') as list:
-            batches_left = []
-            for line in list:
-                batches_left.append(line.strip('\n'))
-        index = ['preprocessed/{s}_data.vcf.gz.csi'.format(s=batch) for batch in batches_left]
-        vcf = ['preprocessed/{s}_data.vcf.gz'.format(s=batch) for batch in batches_left]
-        return index + vcf
 
-    rule merge_vcf:
+if not flow == 'rapid':
+    if NUM_BATCHES > 1:
+        checkpoint convert_mapped_to_plink:
+            input:
+                vcf='preprocessed/{batch}_data.vcf.gz'
+            output:
+                bed='preprocessed/{batch}_data.bed',
+                fam='preprocessed/{batch}_data.fam',
+                bim='preprocessed/{batch}_data.bim'
+            params:
+                out='preprocessed/{batch}_data'
+            conda:
+                'plink'
+            log:
+                'logs/plink/convert_mapped_to_plink{batch}.log'
+            benchmark:
+                'benchmarks/plink/convert_mapped_to_plink{batch}.txt'
+            shell:
+                '''
+                plink --vcf {input} --make-bed --out {params.out} |& tee {log}
+                '''
+
+
+        def get_merge_bed_input(wildcards):
+            with open('pass_batches.list','r') as list:
+                batches_left = []
+                for line in list:
+                    batches_left.append(line.strip('\n'))
+                bim = ['preprocessed/{s}_data.bim'.format(s=batch) for batch in batches_left]
+                bed = ['preprocessed/{s}_data.bed'.format(s=batch) for batch in batches_left]
+                fam = ['preprocessed/{s}_data.fam'.format(s=batch) for batch in batches_left]
+            return bed + bim + fam
+
+        rule merge_bed:
+            input:
+                get_merge_bed_input
+            output:
+                bed='preprocessed/data.bed',
+                fam='preprocessed/data.fam',
+                bim='preprocessed/data.bim'
+            threads:
+                workflow.cores
+            conda:
+                'plink'
+            shell:
+                '''
+                rm files_list.txt || true
+                for file in {input}
+                do
+                    if [[ $file == *.fam ]]
+                    then
+                        echo ${{file%.*}} >> files_list.txt
+                    fi
+                done
+
+                plink --merge-list files_list.txt --make-bed --out preprocessed/data
+                rm files_list.txt
+                '''
+
+
+        rule index_vcf:
+            input:
+                batches_vcf='preprocessed/{batch}_data.vcf.gz'
+            output:
+                batches_vcf_index=temp('preprocessed/{batch}_data.vcf.gz.csi')
+            conda:
+                'bcftools'
+            shell:
+                '''
+                bcftools index -f {input.batches_vcf}
+                '''
+
+        def get_merge_vcf_input(wildcards):
+            with open('pass_batches.list', 'r') as list:
+                batches_left = []
+                for line in list:
+                    batches_left.append(line.strip('\n'))
+            index = ['preprocessed/{s}_data.vcf.gz.csi'.format(s=batch) for batch in batches_left]
+            vcf = ['preprocessed/{s}_data.vcf.gz'.format(s=batch) for batch in batches_left]
+            return index + vcf
+
+        rule merge_vcf:
+            input:
+                get_merge_vcf_input
+            output:
+                vcf='preprocessed/data.vcf.gz'
+            threads:
+                workflow.cores
+            params:
+                batches_vcf=expand('batch{s}_data.vcf.gz',s=BATCHES),
+                vcf='data.vcf.gz'
+            conda:
+                'bcftools'
+            shell:
+                '''
+                rm complete_vcf_list.txt || true
+                for FILE in {input}
+                do
+                    if [[ $FILE == *.gz ]]
+                    then
+                        echo $FILE >> complete_vcf_list.txt
+                    fi
+                done
+                bcftools merge --threads {threads} --file-list complete_vcf_list.txt --force-samples -O z -o {output.vcf}
+                rm complete_vcf_list.txt
+                '''
+
+    else:
+        rule single_batch_convert_mapped_to_plink:
+            input:
+                vcf='preprocessed/data.vcf.gz'
+            output:
+                bed='preprocessed/data.bed',
+                fam='preprocessed/data.fam',
+                bim='preprocessed/data.bim'
+            params:
+                out='preprocessed/data'
+            conda:
+                'plink'
+            log:
+                'logs/plink/convert_mapped_to_plink_batch1.log'
+            benchmark:
+                'benchmarks/plink/convert_mapped_to_plink_batch1.txt'
+            shell:
+                '''
+                plink --vcf {input} --make-bed --out {params.out} |& tee {log}
+                '''
+
+
+    rule ibis_mapping:
         input:
-            get_merge_vcf_input
-        output:
-            vcf='preprocessed/data.vcf.gz'
-        threads:
-            workflow.cores
-        params:
-            batches_vcf=expand('batch{s}_data.vcf.gz',s=BATCHES),
-            vcf='data.vcf.gz'
-        conda:
-            'bcftools'
-        shell:
-            '''
-            rm complete_vcf_list.txt || true
-            for FILE in {input}
-            do
-                if [[ $FILE == *.gz ]]
-                then
-                    echo $FILE >> complete_vcf_list.txt
-                fi
-            done
-            bcftools merge --threads {threads} --file-list complete_vcf_list.txt --force-samples -O z -o {output.vcf}
-            rm complete_vcf_list.txt
-            '''
-
-else:
-    rule single_batch_convert_mapped_to_plink:
-        input:
-            vcf='preprocessed/data.vcf.gz'
-        output:
-            bed='preprocessed/data.bed',
-            fam='preprocessed/data.fam',
             bim='preprocessed/data.bim'
         params:
-            out='preprocessed/data'
+            genetic_map_GRCh37=expand(GENETIC_MAP_GRCH37,chrom=CHROMOSOMES)
         conda:
-            'plink'
+            'ibis'
+        output:
+            'preprocessed/data_mapped.bim'
         log:
-            'logs/plink/convert_mapped_to_plink_batch1.log'
+            'logs/ibis/run_ibis_mapping.log'
         benchmark:
-            'benchmarks/plink/convert_mapped_to_plink_batch1.txt'
+            'benchmarks/ibis/run_ibis_mapping.txt'
         shell:
             '''
-            plink --vcf {input} --make-bed --out {params.out} |& tee {log}
+            (add-map-plink.pl -cm {input.bim} {params.genetic_map_GRCh37}> {output}) |& tee -a {log}
             '''
-
-
-rule ibis_mapping:
-    input:
-        bim='preprocessed/data.bim'
-    params:
-        genetic_map_GRCh37=expand(GENETIC_MAP_GRCH37,chrom=CHROMOSOMES)
-    conda:
-        'ibis'
-    output:
-        'preprocessed/data_mapped.bim'
-    log:
-        'logs/ibis/run_ibis_mapping.log'
-    benchmark:
-        'benchmarks/ibis/run_ibis_mapping.txt'
-    shell:
-        '''
-        (add-map-plink.pl -cm {input.bim} {params.genetic_map_GRCh37}> {output}) |& tee -a {log}
-        '''

--- a/scripts/client_background_test.py
+++ b/scripts/client_background_test.py
@@ -52,10 +52,10 @@ def extract_cb_matches_from_local(input150_path: str, input18_path: str, local_m
 if __name__ == '__main__':
     input150_samples_path = 'workdir/input150.samples'    
     input18_samples_path = 'workdir/input18.samples'
-    local_matches_path = 'workdir/relatives_input168.tsv'
-    
-    local_cb_matches_path = 'workdir/relatives_18_150.tsv'
+    local_matches_path = 'workdir/relatives_ibis168.tsv'
     cb_matches_path = 'workdir/relatives_cb_input18_150.tsv'
+    
+    local_cb_matches_path = 'workdir/relatives_18_150_2.tsv'
     
     extract_cb_matches_from_local(input150_samples_path, input18_samples_path, local_matches_path, local_cb_matches_path)
     compare_cb_local_matches(cb_matches_path, local_cb_matches_path)

--- a/scripts/postprocess_ersa.py
+++ b/scripts/postprocess_ersa.py
@@ -112,7 +112,7 @@ if __name__ == '__main__':
             print("ersa postprocess input is empty")
             open(output_path, "w").close()  # create empty output to avoid error
             quit()
-    if snakemake.params['ibis']:
+    if snakemake.params.get('ibis', True):
         ibd = read_ibis(ibd_path)
     else:
         _columns = [

--- a/scripts/postprocess_ersa.py
+++ b/scripts/postprocess_ersa.py
@@ -195,7 +195,7 @@ if __name__ == '__main__':
         .otherwise(shared_genome_formula)
         .alias('shared_genome_proportion')
     )
-    relatives = relatives.filter(pl.col('final_degree').is_null() is False).collect(streaming=True)
+    relatives = relatives.filter(~(pl.col('final_degree').is_null())).collect(streaming=True)
     print(f'We have {len(relatives.filter(dup_mask))} duplicates, '
           f'{len(relatives.filter(fs_mask))} full siblings and '
           f'{len(relatives.filter(po_mask))} parent-offspring relationships')

--- a/scripts/remove_relatives.py
+++ b/scripts/remove_relatives.py
@@ -1,23 +1,35 @@
 import pandas as pd
 import networkx as nx
-relatives = pd.read_csv('./relatives.tsv', sep = '\t')
-total_rel = len(list(set(list(relatives['id1'].unique()) + list(relatives['id2'].unique()))))
-relatives = relatives.loc[relatives.final_degree < 7]
-G = nx.Graph()
-G.add_weighted_edges_from(zip(relatives.id1, relatives.id2, relatives.final_degree))
+import logging
 
-def rm_node(g):
-  remove_list = []
-  degree_dict = {node:val for (node, val) in g.degree()}
-  while max(degree_dict.values()) > 0:
-    degree_dict = {node:val for (node, val) in g.degree()}
-    max_node = max(degree_dict, key=degree_dict.get)
-    remove_list.append(max_node)
-    g.remove_node(max_node)
-  return remove_list
 
-remove_list = rm_node(G)
-print(f"{total_rel - len(remove_list)} out of {total_rel} relatives left after cleaning, {len(remove_list)} was removed!")
+if __name__ == '__main__':
+
+    logging.basicConfig(filename='log.log', level=logging.DEBUG, format='%(levelname)s:%(asctime)s %(message)s')
+
+    relatives_path = snakemake.input['relatives']
+    # within families
+    # across families
+    output_path = snakemake.output['remove_list']
     
-with open('./remove_list.txt', 'w') as rm:
-  rm.write('\n'.join(remove_list))
+    relatives = pd.read_csv(relatives_path, sep = '\t')
+    total_rel = len(list(set(list(relatives['id1'].unique()) + list(relatives['id2'].unique()))))
+    relatives = relatives.loc[relatives.final_degree < 7]
+    G = nx.Graph()
+    G.add_weighted_edges_from(zip(relatives.id1, relatives.id2, relatives.final_degree))
+
+    def rm_node(g):
+      remove_list = []
+      degree_dict = {node:val for (node, val) in g.degree()}
+      while max(degree_dict.values()) > 0:
+        degree_dict = {node:val for (node, val) in g.degree()}
+        max_node = max(degree_dict, key=degree_dict.get)
+        remove_list.append(max_node)
+        g.remove_node(max_node)
+      return remove_list
+
+    remove_list = rm_node(G)
+    print(f"{total_rel - len(remove_list)} out of {total_rel} relatives left after cleaning, {len(remove_list)} was removed!")
+        
+    with open(output_path, 'w') as rm:
+      rm.write('\n'.join(remove_list))

--- a/workflows/preprocess2/Snakefile
+++ b/workflows/preprocess2/Snakefile
@@ -32,14 +32,20 @@ def _mem_gb_for_ram_hungry_jobs():
   return min(_IDEAL_LARGE_MEM_GB, config["mem_gb"])
 
 
-rule all:
-    input:
-        vcf="preprocessed/data.vcf.gz",
-        bed="preprocessed/data.bed",
-        fam="preprocessed/data.fam",
-        bim_mapped="preprocessed/data_mapped.bim",
-        bim="preprocessed/data.bim"
-        # rules.report_benchmark_summary.output
+if flow == 'rapid':
+    rule all:
+        input:
+            vcf="preprocessed/data.vcf.gz",
+            fam="preprocessed/data.fam"
+else:
+    rule all:
+        input:
+            vcf="preprocessed/data.vcf.gz",
+            bed="preprocessed/data.bed",
+            fam="preprocessed/data.fam",
+            bim_mapped="preprocessed/data_mapped.bim",
+            bim="preprocessed/data.bim"
+            # rules.report_benchmark_summary.output
 
 
 include: "../../rules/preprocessing.smk"

--- a/workflows/remove_relatives/Snakefile
+++ b/workflows/remove_relatives/Snakefile
@@ -19,10 +19,6 @@ SITE_1000GENOME = join(REF_DIR, config["reference"]["SITE_1000GENOME"]["file"])
 flow               = config["flow"]
 is_client          = config["mode"] == "client"
 use_simulated_ibd  = config["use_simulated_ibd"] if "use_simulated_ibd" in config else False
-HAPMAP_PED         = join(REF_DIR, config["reference"]["hapmap_ped"]["file"])
-HAPMAP_MP          = join(REF_DIR, config["reference"]["hapmap_mp"]["file"])
-HAPMAP_FAM         = join(REF_DIR, config["reference"]["hapmap_fam"]["file"])
-PEDSIM_MAP         = join(REF_DIR, config["reference"]["pedsim_map"]["file"])
 
 print('execution mode is: ' + config["mode"])
 
@@ -43,44 +39,9 @@ def _mem_gb_for_ram_hungry_jobs():
 
 rule all:
     input:
-        data="background.vcf.gz",
-        list="list.samples"
+        back = "background.vcf.gz",
+        list_samples = "list.samples"
 
-rule intersect:
-    input:
-        hd_genotype_chip=AFFYMETRIX_CHIP,
-        vcfRef=REF_VCF
-    output: "phased/chr{chrom}.phased.vcf.gz"
-    conda: "bcftools"
-    shell:
-        """
-            bcftools isec -n=2 -w1 -r {wildcards.chrom} -O z -o {output} {input.vcfRef} {input.hd_genotype_chip}
-        """
-
-
-rule merge_background:
-    input:
-        data=expand("phased/chr{chrom}.phased.vcf.gz", chrom=CHROMOSOMES)
-    output:
-        "input.vcf.gz"
-    params:
-        list="phased/phased.merge.list"
-    conda:
-        "bcftools"
-    shell:
-        """
-            # for now just skip empty files
-            true > {params.list} && \
-            for i in {input.data}; do
-                if [ -s $i ]
-                then
-                    echo $i >> {params.list}
-                else
-                    continue
-                fi
-            done
-            bcftools concat -f {params.list} -O z -o {output}
-        """
 
 include: "../../rules/preprocessing.smk"
 if flow == 'ibis':
@@ -89,6 +50,8 @@ elif flow == 'germline':
     include: "../../rules/relatives.smk"
 elif flow == 'ibis_king':
     include: "../../rules/relatives_ibis_king.smk"
+elif flow == 'rapid':
+    include: "../../rules/relatives_rapid.smk"
 
 rule clean_relatives:
     input:
@@ -99,6 +62,7 @@ rule clean_relatives:
         "remove_relatives"
     script:
         "../../scripts/remove_relatives.py"
+
 
 rule create_chip:
     input:
@@ -113,6 +77,6 @@ rule create_chip:
         "bcftools"
     shell:
         """
-            bcftools view {input.background} --force-samples --samples-file {input.remove_list} -O z -o {output.back}
+            bcftools view {input.background} --force-samples --samples-file ^{input.remove_list} -O z -o {output.back}
             bcftools query --list-samples {output.back} > list.samples
         """

--- a/workflows/simbig/Snakefile
+++ b/workflows/simbig/Snakefile
@@ -125,8 +125,8 @@ rule simulate:
         intf='params/nu_p_campbell.tsv',
         seg = "background/segment{runs}.vcf.gz"
     output:
-        temp('gen{runs}/data{runs}.vcf.gz')
-        # temp('gen{runs}/data{runs}.seg')
+        temp('gen{runs}/data{runs}.vcf.gz'),
+        temp('gen{runs}/data{runs}.seg')
     conda:
         "ped-sim"
     shell:
@@ -135,7 +135,6 @@ rule simulate:
                 -m {input._map} -i {input.seg} \
                 -o gen{wildcards.runs}/data{wildcards.runs} \
                 --intf {input.intf} --keep_phase
-            rm gen{wildcards.runs}/data{wildcards.runs}.seg
         """
 
 


### PR DESCRIPTION
1. Using more symlinks instead of copying files in preprocessing workflow. It significantly reduces disk usage.
2. remove_relatives workflow directly outputs dataset without distant and close relatives
3. Fixed a bug where some unrelated pairs of samples were written to the final output results/relatives.tsv