### PR TITLE
libarchive13 buster fix

### DIFF
--- a/containers/snakemake/Dockerfile
+++ b/containers/snakemake/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH /opt/conda/bin:${PATH}
 ENV LANG C.UTF-8
 ENV SHELL /bin/bash
 
-RUN apt-get update && apt-get install -y wget bzip2 gnupg2 git libgomp1 && \
+RUN apt-get update && apt-get install -y wget bzip2 gnupg2 git libgomp1 libarchive13 && \
     wget -nv https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
     bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/conda && \
     rm Miniconda3-latest-Linux-x86_64.sh && \


### PR DESCRIPTION
libarchive13 is required to build the snakemake container. 