### PR TITLE
[Issue-106] Switch to official Snakemake version

### DIFF
--- a/envs/snakemake.yaml
+++ b/envs/snakemake.yaml
@@ -14,8 +14,4 @@ dependencies:
   - scikit-bio==0.5.6
   - docutils==0.16
   - mmh3==3.0.0
-  - pip:
-    - "--editable=git+https://github.com/Jahysama/snakemake.git#egg=snakemake"
-    #Fork of a snakemake is used here because of not working conda envs inside python scripts
-    #Please check out https://github.com/snakemake/snakemake/pull/1812 for more info
-
+  - snakemake==7.30.1


### PR DESCRIPTION
Please switch snakemake installation from my fork to official python package. It shouldn't make any difference, since my fork is already up to date with 7.30.1 version of the package.
(I just really want to change my github nickname without breaking anything😅)