### PR TITLE
[ISSUE-110] Changed tbi indexes to csi indexes

### DIFF
--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -2,20 +2,20 @@ rule index_for_eagle:
     input:
         bcf='vcf/{batch}_merged_mapped_sorted.bcf.gz'
     output:
-        idx='vcf/{batch}_merged_mapped_sorted.bcf.gz.tbi'
+        idx='vcf/{batch}_merged_mapped_sorted.bcf.gz.csi'
     log:
-        'logs/vcf/{batch}_merged_mapped_sorted.bcf.gz.tbi.log'
+        'logs/vcf/{batch}_merged_mapped_sorted.bcf.gz.csi.log'
     conda:
         'bcftools'
     shell:
         '''
-            bcftools index -f -t {input.bcf} |& tee {log}
+            bcftools index -f {input.bcf} |& tee {log}
         '''
 
 rule phase:
         input:
             vcf='vcf/{batch}_merged_mapped_sorted.bcf.gz',
-            idx='vcf/{batch}_merged_mapped_sorted.bcf.gz.tbi',
+            idx='vcf/{batch}_merged_mapped_sorted.bcf.gz.csi',
             vcfRef=REF_VCF
         output: temp('phase/{batch}_chr{chrom}.phased.bcf.gz')
         log:

--- a/rules/phasing.smk
+++ b/rules/phasing.smk
@@ -17,14 +17,14 @@ rule phase:
             vcf='vcf/{batch}_merged_mapped_sorted.bcf.gz',
             idx='vcf/{batch}_merged_mapped_sorted.bcf.gz.csi',
             vcfRef=REF_VCF
-        output: temp('phase/{batch}_chr{chrom}.phased.bcf.gz')
+        output: temp('phase/{batch}_chr{chrom}.phased.bcf')
         log:
             'logs/phase/{batch}_eagle-{chrom}.log'
         benchmark:
             'benchmarks/phase/{batch}_eagle-{chrom}.txt'
         shell:
             '''
-            eagle --vcfRef {input.vcfRef} \
+            eagle --vcfRef={input.vcfRef} \
             --vcfTarget {input.vcf}  \
             --geneticMapFile {GENETIC_MAP} \
             --chrom {wildcards.chrom} \
@@ -35,7 +35,7 @@ rule phase:
             '''
 
 
-phase = ['chr{i}.phased.bcf.gz'.format(i=chr) for chr in CHROMOSOMES]
+phase = ['chr{i}.phased.bcf'.format(i=chr) for chr in CHROMOSOMES]
 phase_batch = [ 'phase/{batch}_' + line for line in phase]
 rule merge_phased:
     input:


### PR DESCRIPTION
Thank you @lordkev for pointing out this problem. Your suggested solution fixed the issue! I have tested it on simulation workflow and eagle works without interruption.
I have encountered another strange bug when using eagle and setting `--vcfOutFormat b`, which should output `.bcf.gz` file, outputs just `.bcf`, however it is still indeed compressed despite lacking `.gz` suffix
Closes #110 